### PR TITLE
Here's my plan to refactor the test structure and naming for clarity …

### DIFF
--- a/tests/regression/position-statements.collision.regression.spec.ts
+++ b/tests/regression/position-statements.collision.regression.spec.ts
@@ -2,14 +2,14 @@ import { expect } from '@playwright/test';
 import { test } from '../fixtures';
 import { constants } from '../../pom_utils/config/constants';
 
-test.describe('Collision Regression Tests', () => {
-    test.describe.configure({ mode: 'serial' });
+test.describe('Position Statements Collision Regression Tests', () => {
+    test.setTimeout(60000); // Moved timeout to describe level
+
     test('should validate Position Statements in Collision is correct', async ({
         authenticatedPage,
         homePage,
         collisionPage }) => {
             
-        test.setTimeout(60000);
         await test.step('Navigate to Collision Page', async () => {
             await collisionPage.navigateToCollisionPage();
             expect(await collisionPage.verifyCollisionPageTitle()).toBeTruthy();
@@ -18,7 +18,7 @@ test.describe('Collision Regression Tests', () => {
             await collisionPage.navigateToPositionStatementsVehicle(0);
             await collisionPage.clickCollisionReferenceLink();
             await collisionPage.clickPositionStatementsLink();
-            expect(collisionPage.verifyPositionStatementsTitle()).toBeTruthy();
+            expect(await collisionPage.verifyPositionStatementsTitle()).toBeTruthy(); // verifyPositionStatementsTitle does not return a boolean
         });
         await test.step('Navigate to article from the Position Statements article list (test vehicle 1)', async () => {
             let articleName = await collisionPage.navigateRandomPositionStatementsArticle();
@@ -27,7 +27,7 @@ test.describe('Collision Regression Tests', () => {
         await test.step('Navigate to Position Statements from vehicle details page (test vehicle 1)', async () => {
             await collisionPage.clickSubheaderYMME();
             await collisionPage.clickPositionStatementsLink();
-            expect(collisionPage.verifyPositionStatementsTitle()).toBeTruthy();
+            expect(await collisionPage.verifyPositionStatementsTitle()).toBeTruthy(); // verifyPositionStatementsTitle does not return a boolean
         });
         await test.step('Navigate to article from the Position Statements article list (test vehicle 1)', async () => {
             let articleName = await collisionPage.navigateRandomPositionStatementsArticle();
@@ -40,7 +40,7 @@ test.describe('Collision Regression Tests', () => {
         await test.step('Navigate to Position Statements via Collision Reference (test vehicle 2)', async () => {
             await collisionPage.clickCollisionReferenceLink();
             await collisionPage.clickPositionStatementsLink();
-            expect(collisionPage.verifyPositionStatementsTitle()).toBeTruthy();
+            expect(await collisionPage.verifyPositionStatementsTitle()).toBeTruthy(); // verifyPositionStatementsTitle does not return a boolean
         });
         await test.step('Navigate to article from the Position Statements article list (test vehicle 2)', async () => {
             let articleName = await collisionPage.navigateRandomPositionStatementsArticle();
@@ -49,13 +49,14 @@ test.describe('Collision Regression Tests', () => {
         await test.step('Navigate to Position Statements from vehicle details page (test vehicle 2)', async () => {
             await collisionPage.clickSubheaderYMME();
             await collisionPage.clickPositionStatementsLink();
-            expect(collisionPage.verifyPositionStatementsTitle()).toBeTruthy();
+            expect(await collisionPage.verifyPositionStatementsTitle()).toBeTruthy(); // verifyPositionStatementsTitle does not return a boolean
         });
         await test.step('Navigate to article from the Position Statements article list (test vehicle 2)', async () => {
             let articleName = await collisionPage.navigateRandomPositionStatementsArticle();
             expect(await collisionPage.getPositionStatementsArticleTitle()).toContain(articleName);
         });
     });
+
     test('should validate Position Statements open correctly in new tabs', async ({
         authenticatedPage,
         homePage,
@@ -68,7 +69,7 @@ test.describe('Collision Regression Tests', () => {
             await collisionPage.navigateToPositionStatementsVehicle(0);
             await collisionPage.clickCollisionReferenceLink();
             await collisionPage.clickPositionStatementsLink();
-            expect(collisionPage.verifyPositionStatementsTitle()).toBeTruthy();
+            expect(await collisionPage.verifyPositionStatementsTitle()).toBeTruthy(); // verifyPositionStatementsTitle does not return a boolean
         });
         await test.step('Navigate to Article in a new tab and validate is not blank', async () => {
             await collisionPage.navigateToPathWithinNewTab(await collisionPage.getRandomPositionStatementsArticlePath());

--- a/tests/regression/regression.spec.ts
+++ b/tests/regression/regression.spec.ts
@@ -1,8 +1,0 @@
-import { expect } from '@playwright/test';
-import { test } from '../fixtures';
-
-test.describe('Regression Tests', () => {
-    test.setTimeout(60000);
-
-    // Your regression tests will go here
-});

--- a/tests/regression/repair-planner-validations.regression.spec.ts
+++ b/tests/regression/repair-planner-validations.regression.spec.ts
@@ -3,8 +3,6 @@ import { test } from '../fixtures';
 import { constants } from '../../pom_utils/config/constants';
 
 test.describe('UI Validation Regression Tests', () => {
-    test.describe.configure({ mode: 'serial' });
-    let estimateId: string;
     test.setTimeout(60000);
 
     test('should validate no vehicle decoded message (GENCO-306)', async ({ authenticatedPage,
@@ -14,6 +12,7 @@ test.describe('UI Validation Regression Tests', () => {
         repairPlannerPage }) => {
         test.info().annotations.push({ type: 'issue', description: 'GENCO-306' });
         
+        let estimateId: string; // estimateId is now local to this test
         const expectedStatusCode = 201;
         await test.step('Post estimate', async () => {
             const response = await estimateAPI.postEstimate(authToken);
@@ -39,14 +38,22 @@ test.describe('UI Validation Regression Tests', () => {
         repairPlannerPage }) => {
         test.info().annotations.push({ type: 'issue', description: 'GENCO-307' });
 
+        let localEstimateId: string; 
+        await test.step('Post estimate for ADAS test', async () => {
+            const response = await estimateAPI.postEstimate(authToken);
+            expect(response.statusCode, 'Estimate creation status code should match').toBe(201);
+            localEstimateId = response.estimateId;
+            expect(localEstimateId, 'Estimate ID should be present').toBeTruthy();
+        });
+
         await test.step('Map estimate to vehicle', async () => {
-            await estimateAPI.mapEstimateToVehicle(authToken, estimateId, constants.TEST_VEHICLE.vehicleId);
+            await estimateAPI.mapEstimateToVehicle(authToken, localEstimateId, constants.TEST_VEHICLE.vehicleId);
         });
         await test.step('Navigate to estimate using URL parameter', async () => {
-            await repairPlannerPage.navigateToEstimateWithId(estimateId);
+            await repairPlannerPage.navigateToEstimateWithId(localEstimateId);
             expect(await repairPlannerPage.isSearchInputVisible(), 'Search input should be visible').toBe(true);
             const searchValue = await repairPlannerPage.getSearchDocumentsValue();
-            expect(searchValue, 'Search value should match estimate ID').toEqual(String(estimateId));
+            expect(searchValue, 'Search value should match estimate ID').toEqual(String(localEstimateId));
         });
         await test.step('Press Vital Repairs button', async () => {
             await repairPlannerPage.navigateToVitalRepairs();
@@ -62,12 +69,24 @@ test.describe('UI Validation Regression Tests', () => {
         repairPlannerPage }) => {
         test.info().annotations.push({ type: 'issue', description: 'GENCO-309' });
         
+        let localEstimateId: string;
+        await test.step('Post estimate for Library Request test', async () => {
+            const response = await estimateAPI.postEstimate(authToken);
+            expect(response.statusCode, 'Estimate creation status code should match').toBe(201);
+            localEstimateId = response.estimateId;
+            expect(localEstimateId, 'Estimate ID should be present').toBeTruthy();
+        });
+
+        await test.step('Map estimate to vehicle for Library Request test', async () => {
+            await estimateAPI.mapEstimateToVehicle(authToken, localEstimateId, constants.TEST_VEHICLE.vehicleId);
+        });
+        
         let vehicleDetails;
         await test.step('Navigate to estimate using URL parameter', async () => {
-            await repairPlannerPage.navigateToEstimateWithId(estimateId);
+            await repairPlannerPage.navigateToEstimateWithId(localEstimateId);
             expect(await repairPlannerPage.isSearchInputVisible(), 'Search input should be visible').toBe(true);
             const searchValue = await repairPlannerPage.getSearchDocumentsValue();
-            expect(searchValue, 'Search value should match estimate ID').toEqual(String(estimateId));
+            expect(searchValue, 'Search value should match estimate ID').toEqual(String(localEstimateId));
         });
         await test.step('Get decoded vehicle YMME details', async () => {
             vehicleDetails = await dataWebServicesAPI.getVehicleDetailsByID(authToken, constants.TEST_VEHICLE.vehicleId);

--- a/tests/smoke/auth.smoke.spec.ts
+++ b/tests/smoke/auth.smoke.spec.ts
@@ -1,0 +1,16 @@
+import { expect } from '@playwright/test';
+import { test } from '../fixtures';
+import { constants } from '../../pom_utils/config/constants';
+
+test.describe('Authentication Smoke Tests', () => {
+    test.setTimeout(60000);
+
+    test('should handle invalid login attempt', async ({ loginPage }) => {
+        test.info().annotations.push({ type: 'skipLogout', description: 'No need to logout' });
+
+        await test.step('Attempt invalid login', async () => {
+            await loginPage.loginWithCredentials('invalid_user', 'invalid_pass');
+            expect(await loginPage.isLoginErrorVisible(), 'Login error message should be visible').toBe(true);
+        });
+    });
+});

--- a/tests/smoke/core-ui.smoke.spec.ts
+++ b/tests/smoke/core-ui.smoke.spec.ts
@@ -1,0 +1,61 @@
+import { expect } from '@playwright/test';
+import { test } from '../fixtures';
+import { constants } from '../../pom_utils/config/constants';
+
+test.describe('Core UI Smoke Tests', () => {
+    test.setTimeout(60000);
+
+    test('should validate app elements (Login page, home page, Repair Planner)', async ({ 
+        loginPage,
+        homePage,
+        repairPlannerPage 
+    }) => {
+        // Login page validation
+        await test.step('Verify login page elements', async () => {
+            await loginPage.verifyLoginPageElements();
+        });
+
+        await test.step('Login with ADRP user', async () => {
+            await loginPage.login('adrp');
+        });
+
+        // Home page validation
+        await test.step('Verify home page elements', async () => {
+            await homePage.verifyHomePageElements();
+        });
+
+        await test.step('Navigate to ADRP app', async () => {
+            await homePage.navigateToApp('adrp');
+        });
+
+        // Repair Planner validation
+        await test.step('Open and verify Help & Feedback menu', async () => {
+            await repairPlannerPage.openHelpAndFeedback();
+            await repairPlannerPage.verifyHelpMenuElements();
+        });
+
+        await test.step('Verify Repair Planner elements', async () => {
+            await repairPlannerPage.verifyRepairPlannerElements();
+        });
+
+        // App switcher validation
+        await test.step('Verify app switcher', async () => {
+            await homePage.openAppSwitcher();
+            await homePage.verifyAppSwitcherElements();
+            // Click app switcher again to close it
+            await homePage.openAppSwitcher();
+        });
+
+        // Import Document dialog validation
+        await test.step('Open and verify Import Document dialog', async () => {
+            await repairPlannerPage.openImportDocumentDialog();
+            await repairPlannerPage.verifyImportDialogElements();
+            await repairPlannerPage.closeImportDialog();
+        });
+
+        // Logout 
+        await test.step('Logout', async () => {
+            await repairPlannerPage.logout();
+        });
+    });
+});

--- a/tests/smoke/estimate-workflows.smoke.spec.ts
+++ b/tests/smoke/estimate-workflows.smoke.spec.ts
@@ -2,9 +2,8 @@ import { expect } from '@playwright/test';
 import { test } from '../fixtures';
 import { constants } from '../../pom_utils/config/constants';
 
-test.describe('Smoke Tests', () => {
+test.describe('Estimate Workflows Smoke Tests', () => {
     test.setTimeout(60000);
-
 
     test('should successfully create estimate and navigate to ADRP app', async ({ 
         authenticatedPage,
@@ -36,17 +35,6 @@ test.describe('Smoke Tests', () => {
         });
     });
 
-    test('should handle invalid login attempt', async ({ loginPage }) => {
-        test.info().annotations.push({ type: 'skipLogout', description: 'No need to logout' });
-
-        await test.step('Attempt invalid login', async () => {
-            await loginPage.loginWithCredentials('invalid_user', 'invalid_pass');
-            expect(await loginPage.isLoginErrorVisible(), 'Login error message should be visible').toBe(true);
-        });
-    });
-    // #endregion
-
-    // #region Estimate Workflow Tests
     test('should handle automatic estimate navigation scenario', async ({ 
         authenticatedPage,
         authToken,
@@ -94,7 +82,7 @@ test.describe('Smoke Tests', () => {
         await test.step('Logout', async () => {
             await repairPlannerPage.logout();
         });
-});
+    });
 
     test('should manually import an Estimate, map it to a vehicle, then delete it', async ({ 
         authenticatedPage, 
@@ -261,62 +249,4 @@ test.describe('Smoke Tests', () => {
             await repairPlannerPage.logout();
         });
     });
-    
-    // #endregion
-
-     // #region UI Element Validation Tests
-    test('should validate app elements (Login page, home page, Repair Planner)', async ({ 
-        loginPage,
-        homePage,
-        repairPlannerPage 
-    }) => {
-        // Login page validation
-        await test.step('Verify login page elements', async () => {
-            await loginPage.verifyLoginPageElements();
-        });
-
-        await test.step('Login with ADRP user', async () => {
-            await loginPage.login('adrp');
-        });
-
-        // Home page validation
-        await test.step('Verify home page elements', async () => {
-            await homePage.verifyHomePageElements();
-        });
-
-        await test.step('Navigate to ADRP app', async () => {
-            await homePage.navigateToApp('adrp');
-        });
-
-        // Repair Planner validation
-        await test.step('Open and verify Help & Feedback menu', async () => {
-            await repairPlannerPage.openHelpAndFeedback();
-            await repairPlannerPage.verifyHelpMenuElements();
-        });
-
-        await test.step('Verify Repair Planner elements', async () => {
-            await repairPlannerPage.verifyRepairPlannerElements();
-        });
-
-        // App switcher validation
-        await test.step('Verify app switcher', async () => {
-            await homePage.openAppSwitcher();
-            await homePage.verifyAppSwitcherElements();
-            // Click app switcher again to close it
-            await homePage.openAppSwitcher();
-        });
-
-        // Import Document dialog validation
-        await test.step('Open and verify Import Document dialog', async () => {
-            await repairPlannerPage.openImportDocumentDialog();
-            await repairPlannerPage.verifyImportDialogElements();
-            await repairPlannerPage.closeImportDialog();
-        });
-
-        // Logout 
-        await test.step('Logout', async () => {
-            await repairPlannerPage.logout();
-        });
-    });
-    // #endregion
 });


### PR DESCRIPTION
…and maintainability:

- I'll split the tests from `smoke.spec.ts` into `auth.smoke.spec.ts`, `estimate-workflows.smoke.spec.ts`, and `core-ui.smoke.spec.ts`.
- I'll refactor `uiValidation.spec.ts` into `repair-planner-validations.regression.spec.ts`, making the tests independent by removing shared state and serial execution.
- I'll rename `collision.spec.ts` to `position-statements.collision.regression.spec.ts` and remove serial execution. I'll also fix any missing awaits for assertions.
- I'll remove the empty `regression.spec.ts` file.

These changes should improve test organization and reduce inter-dependencies.